### PR TITLE
desktop.c: make dirent extended attributes work on BSD

### DIFF
--- a/desktop.c
+++ b/desktop.c
@@ -4,7 +4,14 @@
  * Copyright (C) Johan Malm 2022
  */
 #define _POSIX_C_SOURCE 200809L
-#define _DEFAULT_SOURCE
+
+/* Allow extended dirent entries */
+#if defined(__linux__)
+	#define _DEFAULT_SOURCE
+#else
+	#define __BSD_VISIBLE 1
+#endif
+
 #include <ctype.h>
 #include <glib.h>
 #include <stdio.h>


### PR DESCRIPTION
Not sure `__linux__` is actually the right thing to check for but it seems easier than to go the other way round and check for varrous bsd variants. Might break cygwin or something like that but I don't particularly care about windows.