### PR TITLE
Add contrib/example-dynamic-root-menu.sh

### DIFF
--- a/contrib/example-dynamic-root-menu.sh
+++ b/contrib/example-dynamic-root-menu.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Example usage (~/.config/labwc/menu.xml):
+#
+#     <?xml version="1.0" encoding="utf-8"?>
+#     <openbox_menu>
+#       <menu id="root-menu" label="" execute="example-dynamic-root-menu.sh"/>
+#     </openbox_menu>
+
+terminal="foot"
+
+printf '%b\n' '<openbox_pipe_menu>
+  <item label="Web Browser">
+    <action name="Execute"><command>firefox</command></action>
+  </item>
+  <item label="Terminal">
+    <action name="Execute" command="'"$terminal"'"/>
+  </item>
+  <item label="Tweaks">
+    <action name="Execute" command="labwc-tweaks"/>
+  </item>
+  <separator />'
+
+labwc-menu-generator -b -t "${terminal}"
+
+printf '%b\n' '<separator />
+  <item label="Reconfigure">
+    <action name="Reconfigure" />
+  </item>
+  <item label="Exit">
+    <action name="Exit" />
+  </item>
+</openbox_pipe_menu>'


### PR DESCRIPTION
...because such menus are supported with the released of labwc 0.8.3

It shows how a simple wrapper can be written around labwc-menu-generator to add some menu entires before and after the generated directories and .desktop entries.